### PR TITLE
Print request error if it happens

### DIFF
--- a/james.py
+++ b/james.py
@@ -47,6 +47,7 @@ import re
 import subprocess
 import sys
 import time
+import traceback
 import webbrowser
 
 try:
@@ -272,6 +273,7 @@ def main():
         try:
             res = requests.post(chief_url, data=payload, stream=True)
         except requests.RequestException:
+            traceback.print_exc()
             print('Error connecting to Chief. Did you connect to the VPN?')
             return 1
 


### PR DESCRIPTION
We were silently dropping the error and suggesting mabye the user
wasn't connected to the vpn. That's great, except it's nice to know
what the actual error was.

This prints the actual error, too.

@mythmon r?